### PR TITLE
Readonly for feed address input.

### DIFF
--- a/prenumerera.html
+++ b/prenumerera.html
@@ -20,7 +20,7 @@ layout: default
 
     <h2 class="new">Via RSS</h2>
     <p>
-    Flödet går även att lägga till i RSS-läsaren. Flödets adress är <input type="text" value="http://feeds2.feedburner.com/webbradion" onclick="this.select();" style="width: 310px; font-size: 1em" />
+    Flödet går även att lägga till i RSS-läsaren. Flödets adress är <input type="text" value="http://feeds2.feedburner.com/webbradion" onclick="this.select();" style="width: 310px; font-size: 1em" readonly="readonly">
     </p>
 
   </div>


### PR DESCRIPTION
This prevents users which accidentally presses any key to lose content.
