### PR TITLE
Add limit for episodes in atom feed

### DIFF
--- a/avsnitt.atom
+++ b/avsnitt.atom
@@ -8,7 +8,7 @@ layout: null
   <link type="application/atom+xml" rel="self" href="http://webbradion.net/avsnitt.atom"/>
   <title>Webbradion - podcast för webbutvecklare</title>
   <updated>{{ site.time | date_to_xmlschema }}</updated>
-  {% for post in site.posts %}<entry>
+  {% for post in site.posts limit: 20 %}<entry>
     <id>tag:webbradion.net,2005:Episode/{{ post.url | split: '/' | last }}</id>
     <published>{{ post.date | date_to_xmlschema }}</published>
     <updated>{{ post.date | date_to_xmlschema }}</updated>


### PR DESCRIPTION
Many external services, like Feedburner, have set limits on how
many items they will parse in a feed. Since the atom feed is a
news source, not an archive we should limit it to the latest
episodes - almost like we do on the front page.
