### PR TITLE
Fix broken permalinks trailing slash

### DIFF
--- a/_posts/2009-03-03-avsnitt-1.md
+++ b/_posts/2009-03-03-avsnitt-1.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/1
+permalink: /avsnitt/1/
 title: Webbradion 1 - Premiär
 description: I det här avsnittet intervjuar vi Jonas Lejon, grundare av Bloggy och får 11 tips om hur man hittar designinspiration.
 length: 56

--- a/_posts/2009-03-12-avsnitt-2.md
+++ b/_posts/2009-03-12-avsnitt-2.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/2
+permalink: /avsnitt/2/
 title: Webbradion 2 - Mashup
 description: Vi träffar Andreas Krohn från Mashup.se samt pratar om CMS, CSS-ramverk och nedläggningen av Digital web magazine.
 length: 45

--- a/_posts/2009-03-30-avsnitt-3.md
+++ b/_posts/2009-03-30-avsnitt-3.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/3
+permalink: /avsnitt/3/
 title: Webbradion 3 - Sökmotorer
 description: Denna gång träffar vi Tomas Wennström på Hittarecept.se och Whats Next. Vi pratar sökmotorer med Tomas och diskuterar varför studenter har svårt att ta till sig programmering i undervisningen.  
 length: 45

--- a/_posts/2009-04-20-avsnitt-4.md
+++ b/_posts/2009-04-20-avsnitt-4.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/4
+permalink: /avsnitt/4/
 title: Webbradion 4 - Webbstandarder
 description: I detta avsnitt träffar vi Åke Järvklo, pratar webbstandarder och tipsar om hur man kan effektivisera e-posthanteringen. 
 length: 49

--- a/_posts/2009-05-05-avsnitt-5.md
+++ b/_posts/2009-05-05-avsnitt-5.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/5
+permalink: /avsnitt/5/
 title: Webbradion 5 - Sökmotoroptimering
 description: Vi pratar sökmotoroptimering med Nikke Lindqvist.
 length: 54

--- a/_posts/2009-05-15-avsnitt-6.md
+++ b/_posts/2009-05-15-avsnitt-6.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/6
+permalink: /avsnitt/6/
 title: Webbradion 6 - Alternativ
 description: I detta avsnitt pratar vi bland annat domännamnsrätt och intervjuar Ola Johansson om AlternativeTo.
 length: 55

--- a/_posts/2009-05-27-avsnitt-7.md
+++ b/_posts/2009-05-27-avsnitt-7.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/7
+permalink: /avsnitt/7/
 title: Webbradion 7 - Reklamfritt
 description: Vi pratar med Jonathan Sulo om webbhotell och hans nya satsning Reklamfritt.se samt svarar på en lyssnarfråga om hur man kommer igång med Ruby on Rails.
 length: 41

--- a/_posts/2009-06-19-avsnitt-8.md
+++ b/_posts/2009-06-19-avsnitt-8.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/8
+permalink: /avsnitt/8/
 title: Webbradion 8 - Pixlar
 description: David intervjuar Ola Sevandersson som byggt den webbaserade Photoshop-ersättaren Pixlr.com. Vi pratar bla. om Opera Unite och kommande Windows 7's avsaknad av Internet Explorer i Europa.
 length: 38

--- a/_posts/2009-07-09-avsnitt-9.md
+++ b/_posts/2009-07-09-avsnitt-9.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/9
+permalink: /avsnitt/9/
 title: Webbradion 9 - Pusha
 description: Vi intervjuar Martin Lindqvist från Pusha.se och pratar om Firefox 3.5 samt PHP 5.3
 length: 35

--- a/_posts/2009-08-18-avsnitt-10.md
+++ b/_posts/2009-08-18-avsnitt-10.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/10
+permalink: /avsnitt/10/
 title: Webbradion 10 - Camp
 description: I detta rekordlånga avsnitt pratar vi säkerhet och intervjuar Ted Valentin och Tomas Wennström. Glöm inte att rösta på oss i Svenska Podradiopriset! (länk nedan) 
 length: 58

--- a/_posts/2009-08-23-avsnitt-11.md
+++ b/_posts/2009-08-23-avsnitt-11.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/11
+permalink: /avsnitt/11/
 title: Webbradion 11 - SSWC
 description: Ett kort avsnitt från SSWC med fyra mini-intervjuer  Appcorn, Tdh, Citysounds.fm och Twingly.
 length: 16

--- a/_posts/2009-09-07-avsnitt-12.md
+++ b/_posts/2009-09-07-avsnitt-12.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/12
+permalink: /avsnitt/12/
 title: Webbradion 12 - Wordpress
 description: Jonas är tillbaka från semestern och pratar Wordpress med Mattias Tengblad. David har letat nyheter som han delar med sig av.
 length: 33

--- a/_posts/2009-09-24-avsnitt-13.md
+++ b/_posts/2009-09-24-avsnitt-13.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/13
+permalink: /avsnitt/13/
 title: Webbradion 13 - Affiliate-SM
 description: David intervjuar Anton Malmberg om Affiliate-SM som snart drar igång. Jonas har trots att han enligt David låter som en knäckehäxa samlat nyheter. 
 length: 38

--- a/_posts/2009-10-09-avsnitt-14.md
+++ b/_posts/2009-10-09-avsnitt-14.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/14
+permalink: /avsnitt/14/
 title: Webbradion 14 - Testning
 description: Jonas intervjuar Simon Sundén om SEO, sociala medier och länkbeten och vi pratar testning av webbplatser.
 length: 67

--- a/_posts/2009-10-21-avsnitt-15.md
+++ b/_posts/2009-10-21-avsnitt-15.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/15
+permalink: /avsnitt/15/
 title: Webbradion 15 - Häng på
 description: David intervjuar Heidi Harman om entreprenörskap och projektet Runalong och så pratar vi lite om vårt beroende av webbtjänster och leverantörerna bakom dessa. 
 length: 49

--- a/_posts/2009-11-05-avsnitt-16.md
+++ b/_posts/2009-11-05-avsnitt-16.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/16
+permalink: /avsnitt/16/
 title: Webbradion 16 - 24hbc
 description: Ett helt avsnitt tillägnat webbnördarnas favoritcamp. Vi intervjuar Joakim Jardenberg och Jonatan Larsson.
 length: 50

--- a/_posts/2009-11-19-avsnitt-17.md
+++ b/_posts/2009-11-19-avsnitt-17.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/17
+permalink: /avsnitt/17/
 title: Webbradion 17 - Best of the best
 description: Vi pratar nya molntjänster, tittar på Googles nya programmeringspråk och intervjuar Erik Lindgren från Omvård.se
 length: 47

--- a/_posts/2009-12-03-avsnitt-18.md
+++ b/_posts/2009-12-03-avsnitt-18.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/18
+permalink: /avsnitt/18/
 title: Webbradion 18 - Manifest
 description: Vi intervjuar ekonomijournalisten Miriam Olsson från Internetworld och diskuterar vikten i att veta vad man står för (främst kanske som företagare). 
 length: 64

--- a/_posts/2009-12-17-avsnitt-19.md
+++ b/_posts/2009-12-17-avsnitt-19.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/19
+permalink: /avsnitt/19/
 title: Webbradion 19 - Toppform
 description: Intervju med Johan Lindfors, teknisk chef på Microsoft. Vi pratar även webbformulär, Etherpad och undersökningar.
 length: 59

--- a/_posts/2010-01-07-avsnitt-20.md
+++ b/_posts/2010-01-07-avsnitt-20.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/20
+permalink: /avsnitt/20/
 title: Webbradion 20 - Framtidstankar
 description: Jonathan Sulo, Anton Johansson, Heidi Harman och Tomas Wennström delar med sig av sina framtidstankar för 2010 samt vad de tyckte om 2009. 
 length: 28

--- a/_posts/2010-01-22-avsnitt-21.md
+++ b/_posts/2010-01-22-avsnitt-21.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/21
+permalink: /avsnitt/21/
 title: Webbradion 21 - Egen
 description: Jonas intervjuar Christian Davén om egenföretagande inom webbranschen och vi diskuterar nedläggningen av Playahead.
 length: 61

--- a/_posts/2010-02-03-avsnitt-22.md
+++ b/_posts/2010-02-03-avsnitt-22.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/22
+permalink: /avsnitt/22/
 title: Webbradion 22 - Projektledning
 description: David intervjuar Therese Reuterswärd om webbprojektledning och vi pratar Rails 3. 
 length: 59

--- a/_posts/2010-02-24-avsnitt-23.md
+++ b/_posts/2010-02-24-avsnitt-23.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/23
+permalink: /avsnitt/23/
 title: Webbradion 23 - Ny och het
 description: Jonas intervjuar Christian Andersson från Get a Newsletter, och vi diskuterar mässor, lösenord och Codeburner.
 length: 49

--- a/_posts/2010-03-10-avsnitt-24.md
+++ b/_posts/2010-03-10-avsnitt-24.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/24
+permalink: /avsnitt/24/
 title: Webbradion 24 - Öppen kundtjänst
 description: I detta avsnitt intervjuar David (med underbar radioröst) Björn Lilja, en av killarna bakom Kundo. Vi går igenom lyssnarundersökningen och pratar ämnen som vanligt. 
 length: 45

--- a/_posts/2010-03-27-avsnitt-25.md
+++ b/_posts/2010-03-27-avsnitt-25.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/25
+permalink: /avsnitt/25/
 title: Webbradion 25 - Undersökningar
 description: Jonas pratar om hur man bäst genomför webbaserade undersökningar och David får en kort pratstund med Erik Sellström på Webbdagarna.
 length: 55

--- a/_posts/2010-04-23-avsnitt-26.md
+++ b/_posts/2010-04-23-avsnitt-26.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/26
+permalink: /avsnitt/26/
 title: Webbradion 26 - Frågvis
 description: David pratar med Emil Gustafsson om Folketfrågar.se och vi pratar om det borttappade http-prefixet i Google chrome samt 14 sätt att vara världens sämsta webbprojektledare.
 length: 37

--- a/_posts/2010-05-12-avsnitt-27.md
+++ b/_posts/2010-05-12-avsnitt-27.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/27
+permalink: /avsnitt/27/
 title: Webbradion 27 - Return of the Ted
 description: Jonas intervjuar Ted Valentin som är tillbaka i Webbradion och pratar om Blogipedia.
 length: 58

--- a/_posts/2010-05-24-avsnitt-28.md
+++ b/_posts/2010-05-24-avsnitt-28.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/28
+permalink: /avsnitt/28/
 title: Webbradion 28 - Word
 description: Vi intervjuar Thord Daniel Hedengren som har skrivit boken "Smashing WordPress  Beyond the Blog", pratar Word Camp, samt Internet Worlds lista över Sveriges hetaste webbfolk
 length: 52

--- a/_posts/2010-06-02-avsnitt-29.md
+++ b/_posts/2010-06-02-avsnitt-29.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/29
+permalink: /avsnitt/29/
 title: Webbradion 29 - Signup
 description: Vi pratar med Bodil Abelsson om SimpleSignup, Google Font API, CSS-strategi och annat smått och gott. 
 length: 53

--- a/_posts/2010-06-17-avsnitt-30.md
+++ b/_posts/2010-06-17-avsnitt-30.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/30
+permalink: /avsnitt/30/
 title: Webbradion 30 - Prestanda
 description: Svante Adermark från Fleecelabs berättar om varför din webbplats är onödigt långsam och ger tips om hur du förbättrar det.
 length: 42

--- a/_posts/2010-06-29-avsnitt-31.md
+++ b/_posts/2010-06-29-avsnitt-31.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/31
+permalink: /avsnitt/31/
 title: Webbradion 31 - Domäner
 description: David intervjuar Fredrik Näs från Domainz och vi diskuterar Yahoos stilguide.
 length: 49

--- a/_posts/2010-08-17-avsnitt-32.md
+++ b/_posts/2010-08-17-avsnitt-32.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/32
+permalink: /avsnitt/32/
 title: Webbradion 32 - Innehåll
 description: Vi snackar innehållstrategi och vad man kan tänka på när det gäller innehåll på en sajt. 
 length: 35

--- a/_posts/2010-09-03-avsnitt-33.md
+++ b/_posts/2010-09-03-avsnitt-33.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/33
+permalink: /avsnitt/33/
 title: Webbradion 33
 description: Ingen intervju den här gången, men vi pratar om jQuery mobile, CakePHP och Rails 3.
 length: 25

--- a/_posts/2010-09-16-avsnitt-34.md
+++ b/_posts/2010-09-16-avsnitt-34.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/34
+permalink: /avsnitt/34/
 title: Webbradion 34
 description: Vi snackar om hur man kan ta emot e-post till sin sajt, lite fler CMS, CSS resets och mikrodata. 
 length: 24

--- a/_posts/2010-09-17-avsnitt-35.md
+++ b/_posts/2010-09-17-avsnitt-35.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/35
+permalink: /avsnitt/35/
 title: Webbradion 35 - Kollektivt
 description: Vi tar ett snack med grabbarna bakom kollektivt.se och diskuterar hur One.com blev avstängda från .SE
 length: 42

--- a/_posts/2010-09-23-avsnitt-36.md
+++ b/_posts/2010-09-23-avsnitt-36.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/36
+permalink: /avsnitt/36/
 title: Webbradion 36 - Campers
 description: Tomas Wennström joinar oss i ett långt och nörderirikt avsnitt. Vi pratar bland annat om Tomas vackertväder.se, SSWC förstås och funderar på hur vilken kodeditor och inställningar som funkar bäst. 
 length: 63

--- a/_posts/2010-09-30-avsnitt-37.md
+++ b/_posts/2010-09-30-avsnitt-37.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/37
+permalink: /avsnitt/37/
 title: Webbradion 37 - Cloud number 9
 description: Googles sökmotoroptimeringsskola och Cloud 9 avhandlas i veckans avsnitt av Webbradion. Gästfritt.
 length: 45

--- a/_posts/2010-10-07-avsnitt-38.md
+++ b/_posts/2010-10-07-avsnitt-38.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/38
+permalink: /avsnitt/38/
 title: Webbradion 38 - Utbildning
 description: Vi bjuder in Johan Leitet som är programansvarig för webbprogrammerarlinjen vid Linnéuniversitetet i Kalmar. Vi pratar utbildning, bättre bildformat för webben, gitnotifieringar och lite annat smått och gott. 
 length: 67

--- a/_posts/2010-10-14-avsnitt-39.md
+++ b/_posts/2010-10-14-avsnitt-39.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/39
+permalink: /avsnitt/39/
 title: Webbradion 39 - TKJ
 description: Tommy K Johansson, Sveriges störste teknikbloggare, besöker webbradion och pratar om hur han drog igång tkj.se. Vi avhandlar även produktivitetstips för webbutvecklare.
 length: 73

--- a/_posts/2010-10-21-avsnitt-40.md
+++ b/_posts/2010-10-21-avsnitt-40.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/40
+permalink: /avsnitt/40/
 title: Webbradion 40 - Bara bom
 description: Lagom till 26 000 nedladdningar av våra avsnitt släpper vi avsnitt 40! Vi tar upp säkerhet, iPhån-utveckling och API-er. 
 length: 42

--- a/_posts/2010-10-30-avsnitt-41.md
+++ b/_posts/2010-10-30-avsnitt-41.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/41
+permalink: /avsnitt/41/
 title: Webbradion 41 - à la Malta
 description: Tore Friskopp berättar hur det fungerar att arbeta på distans, och delar även med sig av erfarenheter från e-handelsbutiken Polyshop. Jonas låser ute sig och missar hela intervjun, men är rätt glad ändå.
 length: 62

--- a/_posts/2010-11-04-avsnitt-42.md
+++ b/_posts/2010-11-04-avsnitt-42.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/42
+permalink: /avsnitt/42/
 title: Webbradion 42 - Upplevelsedesign
 description: Vi har nöjet att få prata med Per Axbom, webbstrategen och upplevelsedesignern, om användarupplevelser och de mer mjuka delarna av webbutveckling. Hur förbättrar man användarens upplevelse av din webbplats?
 length: 65

--- a/_posts/2010-11-11-avsnitt-43.md
+++ b/_posts/2010-11-11-avsnitt-43.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/43
+permalink: /avsnitt/43/
 title: Webbradion 43 - Barca
 description: Jonas har flytt vintern och åkt till Barcelona tillsammans med Simon Hedl .. Hedberg. 
 length: 45

--- a/_posts/2010-12-02-avsnitt-44.md
+++ b/_posts/2010-12-02-avsnitt-44.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/44
+permalink: /avsnitt/44/
 title: Webbradion 44 - Back to Umeå
 description: Lagom till 30000 nedladdningar av Webbradion, är Jonas tillbaka i mörkret i Umeå och vi snackar rekordmånga nyheter! Allt från Git till Topp100. 
 length: 64

--- a/_posts/2010-12-09-avsnitt-45.md
+++ b/_posts/2010-12-09-avsnitt-45.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/45
+permalink: /avsnitt/45/
 title: Webbradion 45 - Lodrätt fyra
 description: Om Amazons DNS-tjänst, hur man använder webbprototyping, och varför Bitly pro är gratis.
 length: 50

--- a/_posts/2011-01-20-avsnitt-46.md
+++ b/_posts/2011-01-20-avsnitt-46.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/46
+permalink: /avsnitt/46/
 title: Back in business!
 description: Vi inleder denna nya säsong och diskuterar Joomla av alla CMS, ergonomi vid skrivbordet och en massa annat smutt och gutt. 2011 blir ett toppenår!
 length: 62

--- a/_posts/2011-02-03-avsnitt-47.md
+++ b/_posts/2011-02-03-avsnitt-47.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/47
+permalink: /avsnitt/47/
 title: Webbradion 47 - Det är mycket nu
 description: Två utarbetade webbutvecklare orkar bara med en halvtimmeslångt avsnitt av webbradion idag.
 length: 32

--- a/_posts/2011-02-10-avsnitt-48.md
+++ b/_posts/2011-02-10-avsnitt-48.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/48
+permalink: /avsnitt/48/
 title: Tema  API!
 description: Andreas Krohn från Mashup.se sluter upp och berättar vad man kan tänka på när man bygger API-er. Vi snackar webbanalys, spelmotorer och mindmaps.
 length: 74

--- a/_posts/2011-03-20-avsnitt-49.md
+++ b/_posts/2011-03-20-avsnitt-49.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/49
+permalink: /avsnitt/49/
 title: Webbradion 49 - E-handel med Anton & Anton
 description: Ännu ett härligt långt avsnitt där vi pratar e-handel med Anton Malmberg och Anton Johansson, men först lite struntprat i sisådär en timme.
 length: 111

--- a/_posts/2011-05-04-avsnitt-50.md
+++ b/_posts/2011-05-04-avsnitt-50.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/50
+permalink: /avsnitt/50/
 title: Webbradion 50 - Developaaaz!
 description: Golf och vårglädje med nya jQuery och lite produktivitetstips. Microsofts Balmer i episk remix. Kan det bli bättre? Senaste nyheterna nerifrån. 
 length: 33

--- a/_posts/2011-05-13-avsnitt-51.md
+++ b/_posts/2011-05-13-avsnitt-51.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/51
+permalink: /avsnitt/51/
 title: Webbradion 51 - Angry nerds
 description: Vi diskuterar Lastpass säkerhetsproblem, hur Heroku fungerar och går igenom en artikel som handlar om vad varje webbutvecklare/webbdesigner borde veta redan innan de börjar jobba.
 length: 47

--- a/_posts/2011-08-11-avsnitt-52.md
+++ b/_posts/2011-08-11-avsnitt-52.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/52
+permalink: /avsnitt/52/
 title: Webbradion 52 - Semester
 description: David och Jonas är tillbaka med ett nytt avsnitt efter semestern. Vi pratar om texteditorn Chocolat, uppgradering till Lion och Appfog för PHP.
 length: 34

--- a/_posts/2011-09-01-avsnitt-53.md
+++ b/_posts/2011-09-01-avsnitt-53.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/53
+permalink: /avsnitt/53/
 title: Webbradion 53 - iZettle
 description: David intervjuar iZettle och vi pratar dependencies och en massa client side-topics!
 length: 53

--- a/_posts/2011-10-03-avsnitt-54.md
+++ b/_posts/2011-10-03-avsnitt-54.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/54
+permalink: /avsnitt/54/
 title: Webbradion 54 - Korkad
 description: Jonas blir attackerad av en kypare och får en champagnekork i huvudet medan vi pratar om Bitbucket som får stöd för Git, RailsCasts som kommer i en Pro-variant och lite om Webbdagarna.
 length: 51

--- a/_posts/2011-10-19-avsnitt-55.md
+++ b/_posts/2011-10-19-avsnitt-55.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/55
+permalink: /avsnitt/55/
 title: Webbradion 55 - Got news
 description: I Berlin rullar det på. Jonas har besök av Jonny Strömberg, designer på MyNewsdesk. Vi diskuterar Jonnys roll som designer och snackar native JavaScript.
 length: 55

--- a/_posts/2011-11-23-avsnitt-56.md
+++ b/_posts/2011-11-23-avsnitt-56.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/56
+permalink: /avsnitt/56/
 title: Webbradion 56 - Microproject!
 description: Jonas snackar med Andreas Sundgren från Microproject kring projektet, hur man tagit fram applikationen och hur resan från idé till att man nått marknaden gått. 
 length: 43

--- a/_posts/2011-11-30-avsnitt-57.md
+++ b/_posts/2011-11-30-avsnitt-57.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/57
+permalink: /avsnitt/57/
 title: Webbradion 57 - Slooow
 description: David och Jonas pratar om vad som gör din webbplats långsam, diskuterar Googles höstrensning och svarar på lyssnarfrågor.
 length: 71

--- a/_posts/2012-01-20-avsnitt-58.md
+++ b/_posts/2012-01-20-avsnitt-58.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/58
+permalink: /avsnitt/58/
 title: Webbradion 58 - Nytt år och JavaScript
 description: Tillbaka från julbordet och nyårschampagnen konstaterar vi att det i mellandagarna förekommit så kallad ninjakodning på Standout i Växjö. Mycket JavaScript detta avsnitt. God fortsättning bästa lyssnare!
 length: 52

--- a/_posts/2012-03-02-avsnitt-59.md
+++ b/_posts/2012-03-02-avsnitt-59.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/59
+permalink: /avsnitt/59/
 title: Webbradion 59 - Bienvenue
 description: David och Jonas nördar till det rejält och pratar om cachning, Twitter bootstrap och Apache 2.4.
 length: 57

--- a/_posts/2012-03-20-avsnitt-60.md
+++ b/_posts/2012-03-20-avsnitt-60.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/60
+permalink: /avsnitt/60/
 title: Webbradion 60 - Truffler!
 description: Jonas snackar sök och framförallt Truffler.net med Henrik Lindström, en av grundarna. 
 length: 43

--- a/_posts/2012-06-25-avsnitt-61.md
+++ b/_posts/2012-06-25-avsnitt-61.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/61
+permalink: /avsnitt/61/
 title: Webbradion 61 - Nerdnews
 description: Standout-utvecklarna Jonas och Andreas hoppar in istället för Arnklint som är på semester. Det resulterar i ett riktigt nördigt avsnitt av webbradion.
 length: 35

--- a/_posts/2012-07-03-avsnitt-62.md
+++ b/_posts/2012-07-03-avsnitt-62.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/62
+permalink: /avsnitt/62/
 title: Webbradion 62 - Hittebo
 description: David får en pratstund med Hittebo-gänget, men först pratar vi jQuery 2, Chrome för iOS och Node JS 0.8.
 length: 61

--- a/_posts/2012-07-31-avsnitt-63.md
+++ b/_posts/2012-07-31-avsnitt-63.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/63
+permalink: /avsnitt/63/
 title: Webbradion 63 - OS
 description: Webbradion diskuterar OS i hela 15 sekunder och ger sig sedan in på riktiga ämnen istället. Safari har kommit i version 6 och David har bytt efternamn.
 length: 49

--- a/_posts/2012-08-06-avsnitt-64.md
+++ b/_posts/2012-08-06-avsnitt-64.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/64
+permalink: /avsnitt/64/
 title: Webbradion 64 - Facebookpoliser
 description: Polisen intar Facebook, Ember JS har släppts i 1.0-pre och Ukulelen tar över ditt tangentbord. Allt detta till bakgrundsmusik ifrån något okänt liveband.
 length: 33

--- a/_posts/2012-08-13-avsnitt-65.md
+++ b/_posts/2012-08-13-avsnitt-65.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/65
+permalink: /avsnitt/65/
 title: Webbradion 65
 description: Textmate blir open source, nyheter i jQuery 1.8 och ett armbandsur i CSS finns bland nyheterna.
 length: 49

--- a/_posts/2012-09-03-avsnitt-66.md
+++ b/_posts/2012-09-03-avsnitt-66.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/66
+permalink: /avsnitt/66/
 title: Webbradion 66 - Webbläsarstatistik
 description: Vi snackar senaste webbläsartrenderna, tar en snabbtitt på kommande Firefox 16, samt går igenom saker du bör tänka på innan du slänger in nästa Wordpress-plugin.
 length: 41

--- a/_posts/2012-09-10-avsnitt-67.md
+++ b/_posts/2012-09-10-avsnitt-67.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/67
+permalink: /avsnitt/67/
 title: Webbradion 67 - Native vs HTML5
 description: Vi pratar om fördelar/nackdelar med olika distributionssätt av mobilappar, Gudruns inverkan på bredbandsutbyggnaden och senaste releasen av Symfony.
 length: 38

--- a/_posts/2012-09-12-avsnitt-68.md
+++ b/_posts/2012-09-12-avsnitt-68.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/68
+permalink: /avsnitt/68/
 title: Webbradion 68 - Tidig bastusession
 description: I första delen i miniserien från SSWC snackar Jonas med Jonny Strömberg kring startup-scenen i Stockholm. 
 length: 14

--- a/_posts/2012-09-17-avsnitt-69.md
+++ b/_posts/2012-09-17-avsnitt-69.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/69
+permalink: /avsnitt/69/
 title: Webbradion 69 - Ljudtest
 description: Vi lägger upp ett litet testavsnitt för att prova nya ljudutrustningen här på kontoret. Det bästa sättet att göra det är väl att köra igenom ett gäng med nyheter?
 length: 20

--- a/_posts/2012-10-01-avsnitt-70.md
+++ b/_posts/2012-10-01-avsnitt-70.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/70
+permalink: /avsnitt/70/
 title: Webbradion 70 - Take two
 description: För andra veckan i rad försöker vi spela in avsnitt 70. Den här gången går det bättre.
 length: 61

--- a/_posts/2012-10-08-avsnitt-71.md
+++ b/_posts/2012-10-08-avsnitt-71.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/71
+permalink: /avsnitt/71/
 title: Webbradion 71 - Tält für alle
 description: Vi pratar om Tent, den distribuerade sociala plattformen och Twitter som blir av med Bootstrap.
 length: 62

--- a/_posts/2012-10-12-avsnitt-72.md
+++ b/_posts/2012-10-12-avsnitt-72.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/72
+permalink: /avsnitt/72/
 title: Webbradion 72 - Fredagsmys
 description: Vi testar att spela in på fredagar istället, och diskuterar autosparande formulär, HTML5-brädspel och retinabilder i CSS.
 length: 50

--- a/_posts/2012-10-21-avsnitt-73.md
+++ b/_posts/2012-10-21-avsnitt-73.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/73
+permalink: /avsnitt/73/
 title: Webbradion 73 - Fyran
 description: Arnklint intervjuar David Hall på TV4 och nyhetsgänget i studion jäktar igenom flera nyheter i snabb takt för att hinna med bussen.
 length: 26

--- a/_posts/2012-10-26-avsnitt-74.md
+++ b/_posts/2012-10-26-avsnitt-74.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/74
+permalink: /avsnitt/74/
 title: Webbradion 74 - Git it?
 description: Två x Jonas i showen den här veckan, där nyhetslistan domineras av Git, Rails och Javascript.
 length: 53

--- a/_posts/2012-11-11-avsnitt-75.md
+++ b/_posts/2012-11-11-avsnitt-75.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/75
+permalink: /avsnitt/75/
 title: Webbradion 75 - Ruby 2
 description: Vi pratar om RC1 av Ruby 2, Cruisecontrol och hur man får folk att förstå programmering.
 length: 45

--- a/_posts/2012-11-23-avsnitt-76.md
+++ b/_posts/2012-11-23-avsnitt-76.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/76
+permalink: /avsnitt/76/
 title: Webbradion 76 - Coding standards
 description: Panelen diskuterar kodningsstandarder, den nya databasen RethinkDb och att Go fyller tre.
 length: 51

--- a/_posts/2012-12-14-avsnitt-77.md
+++ b/_posts/2012-12-14-avsnitt-77.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/77
+permalink: /avsnitt/77/
 title: Webbradion 77 - Jul igen
 description: Året går alldeles för fort när man har roligt. Webbradion sänder förmodligen årets sista avsnitt, och Joacim gör debut som podcastare.
 length: 47

--- a/_posts/2013-01-15-avsnitt-78.md
+++ b/_posts/2013-01-15-avsnitt-78.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/78
+permalink: /avsnitt/78/
 title: Webbradion 78 - Omnicloud
 description: David, Albert och Ross pratar Ruby och Javascript medan Arnklint intervjuar Per Jonsson från Omnicloud. Intervjun börjar cirka 35 minuter in i programmet.
 length: 65

--- a/_posts/2013-02-12-avsnitt-79.md
+++ b/_posts/2013-02-12-avsnitt-79.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/79
+permalink: /avsnitt/79/
 title: Webbradion 79
 description: Vi testar dessutom att dra till med en liten undersökning för att se vilket operativsystem ni kör med. 
 length: 58

--- a/_posts/2013-03-13-avsnitt-80.md
+++ b/_posts/2013-03-13-avsnitt-80.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/80
+permalink: /avsnitt/80/
 title: Webbradion 80
 description: Vi diskuterar AngularJS, Alberts nya Kindle och går igenom förra veckans omröstning.
 length: 49

--- a/_posts/2013-03-26-avsnitt-81.md
+++ b/_posts/2013-03-26-avsnitt-81.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/81
+permalink: /avsnitt/81/
 title: Webbradion 81
 description: Vi pratar om Twitters typahead.js, signerad gems, Fontello och Backbone som kommer i version 1.0.
 length: 43

--- a/_posts/2013-04-11-avsnitt-82.md
+++ b/_posts/2013-04-11-avsnitt-82.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/82
+permalink: /avsnitt/82/
 title: Webbradion 82 - Blinka inte
 description: Vi diskuterar säkerhetsluckor i Postgres och Googles WebKit-urspårning.
 length: 52

--- a/_posts/2013-04-26-avsnitt-83.md
+++ b/_posts/2013-04-26-avsnitt-83.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/83
+permalink: /avsnitt/83/
 title: Webbradion 83 - Shame on you
 description: Vi pratar om Shame CSS, Phonenix-temat för Sublime och introducerar en ny sponsor.
 length: 58

--- a/_posts/2013-05-08-avsnitt-84.md
+++ b/_posts/2013-05-08-avsnitt-84.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/84
+permalink: /avsnitt/84/
 title: Webbradion 84 - Näthinna
 description: Vi pratar om för- och nackdelar med Retina på webben, Rails 4-uppgraderingar och leker med jQuery-plugins.
 length: 52

--- a/_posts/2013-05-27-avsnitt-85.md
+++ b/_posts/2013-05-27-avsnitt-85.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/85
+permalink: /avsnitt/85/
 title: Webbradion 85 - Lätt unikt
 description: Vi pratar om den nya databasen Unqlite, ungefär som SQLite, fast med nosql. Chrome 27 och Pong i CSS är andra saker vi diskuterar. 
 length: 64

--- a/_posts/2013-06-19-avsnitt-86.md
+++ b/_posts/2013-06-19-avsnitt-86.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/86
+permalink: /avsnitt/86/
 title: Webbradion 86 - En kväll i juni
 description: Vi pratar om barnboken Kalle kodare och Jonas nya Ruby-gem för att jämföra diffar.
 length: 57

--- a/_posts/2013-12-13-avsnitt-87.md
+++ b/_posts/2013-12-13-avsnitt-87.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/87
+permalink: /avsnitt/87/
 title: Webbradion 87 - Lucia och otur på samma gång
 description: Gänget är samlat igen och presenterar ett efterlängtat avsnitt av Webbradion där vi försöker få upp tempot efter ett lite längre uppehåll.
 length: 53

--- a/_posts/2013-12-20-avsnitt-88.md
+++ b/_posts/2013-12-20-avsnitt-88.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/88
+permalink: /avsnitt/88/
 title: Webbradion 88 - The Julkalender Edition
 description: Vi pratar om olika julkalendrar för webbutvecklare och vad som händer när man söker på 'rekursiv' i Google.
 length: 57

--- a/_posts/2014-01-10-avsnitt-89.md
+++ b/_posts/2014-01-10-avsnitt-89.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/89
+permalink: /avsnitt/89/
 title: Webbradion 89 - Gott nytt programmeringsspråk
 description: Vi pratar om att webbradion och vårt CMS har blivit öppen sås.
 length: 57

--- a/_posts/2014-01-24-avsnitt-90.md
+++ b/_posts/2014-01-24-avsnitt-90.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/90
+permalink: /avsnitt/90/
 title: Webbradion 90 - Bokklubb med Fortnox
 description: Jonas återvänder och tar med sig kollegan Alexander. Vi pratar om rostiga böcker och sammanfattar vad som hänt sedan senast.
 length: 75

--- a/_posts/2014-03-28-avsnitt-91.md
+++ b/_posts/2014-03-28-avsnitt-91.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/91
+permalink: /avsnitt/91/
 title: Webbradion 91 - Gremlins och hackers
 description: Vi pratar om den nya editorn Atom från GitHub och om hur gremlins kan hjälpa till med testning.
 length: 54

--- a/_posts/2014-04-11-avsnitt-92.md
+++ b/_posts/2014-04-11-avsnitt-92.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/92
+permalink: /avsnitt/92/
 title: Webbradion 92 - Hjärta
 description: Vi bjuder in våra .NET-utvecklare till att prata om säkerhetshålet Heartbleed och frontendramverk.
 length: 55

--- a/_posts/2014-04-29-avsnitt-93.md
+++ b/_posts/2014-04-29-avsnitt-93.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/93
+permalink: /avsnitt/93/
 title: Webbradion 93 - Krossad is i en ström
 description: Vi pratar om Slush tillsammans med utvecklaren Joakim Bengtsson
 length: 55

--- a/_posts/2014-10-01-avsnitt-94.md
+++ b/_posts/2014-10-01-avsnitt-94.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/94
+permalink: /avsnitt/94/
 title: Webbradion 94 - Bylunds tomma sida
 description: Intervju med Jesper Bylund om BlankPage.io
 length: 57

--- a/_posts/2015-09-17-avsnitt-95.md
+++ b/_posts/2015-09-17-avsnitt-95.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/95
+permalink: /avsnitt/95/
 title: Webbradion 95 - Öppna data med Björn Hagström
 description: David Elbe pratar med Björn Hagström om hur Örebro kommun arbetar med öppna data.
 length: 39

--- a/_posts/2015-11-13-avsnitt-96.md
+++ b/_posts/2015-11-13-avsnitt-96.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/96
+permalink: /avsnitt/96/
 title: Webbradion 96 - Öppna data med Lantmäteriet
 description: David Elbe pratar med Peter Nylén om hur Lantmäteriet arbetar med öppna data.
 length: 35

--- a/_posts/2015-11-18-avsnitt-97.md
+++ b/_posts/2015-11-18-avsnitt-97.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/97
+permalink: /avsnitt/97/
 title: Webbradion 97 - Öppna data med Anders Nordh på SKL
 description: David Elbe pratar med Anders Nordh på SKL om hur de arbetar med öppna data.
 length: 36

--- a/_posts/2015-11-20-avsnitt-98.md
+++ b/_posts/2015-11-20-avsnitt-98.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/98
+permalink: /avsnitt/98/
 title: Webbradion 98 - Öppna data med Kristian Bergstrand
 description: David Elbe pratar med Kristian från Helsingborg om hur de arbetar med öppna data.
 length: 44

--- a/_posts/2015-11-23-avsnitt-99.md
+++ b/_posts/2015-11-23-avsnitt-99.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/99
+permalink: /avsnitt/99/
 title: Webbradion 99 - Öppna data med Henrik Fräsén
 description: David Elbe pratar med Henrik från Dödsorsak.se om hur de har använt Socialstyrelsens öppna data.
 length: 29

--- a/_posts/2015-11-26-avsnitt-100.md
+++ b/_posts/2015-11-26-avsnitt-100.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/100
+permalink: /avsnitt/100/
 title: Webbradion 100 - Öppna data med Arbetsförmedlingen
 description: David Elbe pratar med Johanna och Bruce från Arbetsförmedlingen om deras öppna data.
 length: 40

--- a/_posts/2015-11-30-avsnitt-101.md
+++ b/_posts/2015-11-30-avsnitt-101.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/101
+permalink: /avsnitt/101/
 title: Webbradion 101 - Öppna data med Trafiklab
 description: David Elbe pratar med Elias från Trafiklab om deras öppna data.
 length: 50

--- a/_posts/2015-12-08-avsnitt-102.md
+++ b/_posts/2015-12-08-avsnitt-102.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/102
+permalink: /avsnitt/102/
 title: Webbradion 102 - Öppna data med Naturvårdsverket
 description: David Elbe pratar med Ulrika från Naturvårdsverket om deras öppna data.
 length: 26

--- a/_posts/2015-12-22-avsnitt-103.md
+++ b/_posts/2015-12-22-avsnitt-103.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/103
+permalink: /avsnitt/103/
 title: Webbradion 103 - Öppna data med Andreas Krohn
 description: Alexander Ross pratar med Andreas från Helsingborgs stad om deras öppna data, trender och annat.
 length: 42

--- a/_posts/2016-02-23-avsnitt-104.md
+++ b/_posts/2016-02-23-avsnitt-104.md
@@ -1,6 +1,6 @@
 ---
 layout: episode
-permalink: /avsnitt/104
+permalink: /avsnitt/104/
 title: Webbradion 104 - Öppna data med Skjutsgruppen
 description: David pratar med Mattias från Skjutsgruppen
 length: 31


### PR DESCRIPTION
See https://github.com/jekyll/jekyll/issues/4440#issuecomment-178827084

Fixes the broken disqus links here http://webbradion.net/avsnitt/92.

Before: /avsnitt/x worked, but /avsnitt/x/ didn't

After: /avsnitt/x redirects to /avsnitt/x/